### PR TITLE
remove trinkey

### DIFF
--- a/websites.json
+++ b/websites.json
@@ -166,13 +166,6 @@
         "owner": "https://github.com/nuexq"
     },
     {
-        "name": "trinkey",
-        "slug": "trinkey",
-        "about": "the person who made some userstyles",
-        "url": "https://trinkey.com/no-js.html",
-        "owner": "https://github.com/trinkey"
-    },
-    {
         "name": "Duanin2's website",
         "slug": "duanin2",
         "url": "https://duanin2.top/links.html",


### PR DESCRIPTION
I rewrite my website and unfortunately it no longer uses ctp colors so I no longer qualify. I do still have the old version that does have ctp colors at https://old.trinkey.com